### PR TITLE
Update build configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,12 +3,16 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
 formats: all
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.rtd.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,14 @@ dynamic = [
   "keywords",
   "license",
   "classifiers",
-  "version"
+  "version",
+  "dependencies",
+  "readme",
+  "optional-dependencies"
 ]
+
+[project.scripts]
+cobbler-tftp = "cobbler_tftp.cli:cli"
 
 [tool.isort]
 profile = "black"
@@ -58,4 +64,3 @@ showcontent = true
 directory = "fixed"
 name = "Fixed"
 showcontent = true
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,18 +40,23 @@ tests_require =
   pytest-mock>=3.6.1
   pytest-cov>=4.1.0; python_version>"3.6"
   pytest-cov==3.0.0; python_version=="3.6"
+
 lint_requires =
   pre-commit>=2.0.1
   black>=22.1.0
   pyright>=0.0.13
   isort>=5.8.0
   prospector>=1.7.7
+
 doc =
   Sphinx>=5.3.0
   sphinx-rtd-theme>=1.2.0
   towncrier>=22.12.0
+
 dev_requires =
   pip>=21.3.1
 
 [options.packages.find]
 where=src
+exclude =
+  tests*


### PR DESCRIPTION
## Linked Items

Fixes: N/A

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description
According to pip, to build a python application using the hybrid `pyproject.toml` and `setup.py` approach, everything listed in the `setup.cfg` now has to be listed as `dynamic` in the `pyproject.toml`.

This is the error message that states the information. The provided link however is broken.

This should also fix the broken linting and formatting workflows.

```
********************************************************************************
The following seems to be defined outside of `pyproject.toml`:

`dependencies = ['setuptools>=65.5.0', 'wheel>=0.37.1', 'click>=8.1.3', 'questionary>=1.10.0']`

According to the spec (see the link below), however, setuptools CANNOT
consider this value unless `dependencies` is listed as `dynamic`.

https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

To prevent this problem, you can list `dependencies` under `dynamic` or alternatively
remove the `[project]` table from your file and rely entirely on other means of
configuration.
********************************************************************************
```
## Behaviour changes

None.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
