### PR TITLE
Add rudimentary CLI implementation

### DIFF
--- a/changelog.d/13.added
+++ b/changelog.d/13.added
@@ -1,0 +1,1 @@
+Enable setuptools-scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ cobbler-tftp = "cobbler_tftp.cli:cli"
 [tool.isort]
 profile = "black"
 
+[tool.setuptools_scm]
+
 [tool.towncrier]
 directory = "changelog.d"
 filename = "changelog/v{version}.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ packages = find:
 include_package_data = True
 setup_requires =
   setuptools
-  setuptools-scm
+  setuptools-scm>=6.4.2; python_version>"3.6"
+  setuptools-scm==6.4.2; python_version=="3.6"
   wheel
 install_requires =
   fbtftp>=0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ tests_require =
   pytest-cov==3.0.0; python_version=="3.6"
 
 lint_requires =
+  importlib-metadata>=3.10.1
+  importlib-resources>=5.4.0
   pre-commit>=2.0.1
   black>=22.1.0
   pyright>=0.0.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
   pyyaml>=6.0
   click>=8.0.4; python_version>"3.6"
   click==8.0.4; python_version=="3.6"
+  importlib-metadata==3.10.1; python_version=="3.6"
   importlib-resources==5.4.0; python_version=="3.6"
   schema>=0.6.7; python_version>"3.6"
   schema==0.6.7; python_version=="3.6"

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -1,0 +1,109 @@
+"""
+Cobbler-tftp will be managable as a command-line service.
+"""
+
+import click
+import yaml
+
+from cobbler_tftp.settings import SettingsFactory
+
+with open(
+    "src/cobbler_tftp/settings/data/settings.yml", "r", encoding="utf-8"
+) as stream:
+    try:
+        SETTINGS = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+
+_context_settings = dict(help_option_names=["-h", "--help"])
+
+
+@click.group(context_settings=_context_settings, invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
+    """
+    Cobbler-TFTP - Copyright (c) 2022 The Cobbler Team. (github.com/cobbler)\n
+    Licensed under the terms of the GPLv2.0 license.
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(
+            "No commands given, try 'cobbler-tftp -h' or 'cobbler-tftp --help' to view usage."
+        )
+
+        # Possible default behavior can be invoked here
+
+
+@cli.command()
+@click.option(
+    "--no-daemon",
+    "-dd",
+    is_flag=True,
+    default=not SETTINGS["is_daemon"],  # type: ignore
+    help="Stop cobbler-tftp from running as daemon.",
+)
+@click.option(
+    "--enable-automigration",
+    is_flag=True,
+    default=SETTINGS["auto_migrate_settings"],  # type: ignore
+    help="Enable auto migration of settings.",
+)
+@click.option(
+    "--config", "-c", type=click.Path(), help="Set location of configuration file."
+)
+@click.option(
+    "--settings",
+    "-s",
+    multiple=True,
+    help="""Set custom settings in format:\n
+    <PARENT_YAML_KEY>.<CHILD_YAML_KEY>.<...>.<KEY_NAME>=<VALUE>.\n
+    Your settings must use single quotes. If a single quote appears within a value it must be escaped.""",
+)
+def start(no_daemon: bool, enable_automigration, config, settings):
+    """
+    Start the cobbler-tftp server.
+    """
+    click.echo(cli.__doc__)
+    click.echo("Initializing Cobbler-tftp server...")
+    if no_daemon:
+        click.echo("'--no-daemon' flag set. Server running in the foreground...")
+        settings_factory: SettingsFactory = SettingsFactory()
+        # settings_file = SettingsFactory.load_config_file(settings_factory, config)
+        # environment_variables = SettingsFactory.load_env_variables(settings_factory)
+        # cli_arguments = SettingsFactory.load_cli_options(
+        #     settings_factory, daemon, enable_automigration, settings
+        # )
+        application_settings = SettingsFactory.build_settings(
+            settings_factory, config, settings
+        )
+    else:
+        click.echo("Cobbler-tftp will be running as a daemon in the background.")
+
+
+@cli.command()
+def version():
+    """
+    Check cobbler-tftp version. If there are any cobbler servers connected their versions will be printed as well.
+    """
+    pass
+
+
+@cli.command()
+def print_default_config():
+    """
+    Print the default application parameters.
+    """
+    pass
+
+
+@cli.command()
+def stop():
+    """
+    Stop the cobbler-tftp server daemon if it is running
+    """
+    pass
+
+
+cli.add_command(start)
+cli.add_command(version)
+cli.add_command(print_default_config)
+cli.add_command(stop)

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -102,7 +102,8 @@ def print_default_config():
     """
     Print the default application parameters.
     """
-    pass
+    settings_factory: SettingsFactory = SettingsFactory()
+    click.echo(settings_factory.build_settings(None, []))
 
 
 @cli.command()

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -5,7 +5,17 @@ Cobbler-tftp will be managable as a command-line service.
 import click
 import yaml
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:  # use backport for Python versions older than 3.8
+    import importlib_metadata
+
 from cobbler_tftp.settings import SettingsFactory
+
+try:
+    __version__ = importlib_metadata.version("cobbler_tftp")
+except importlib_metadata.PackageNotFoundError:
+    __version__ = "unknown (not installed)"
 
 with open(
     "src/cobbler_tftp/settings/data/settings.yml", "r", encoding="utf-8"
@@ -84,7 +94,7 @@ def version():
     """
     Check cobbler-tftp version. If there are any cobbler servers connected their versions will be printed as well.
     """
-    pass
+    click.echo(f"Cobbler-tftp {__version__}")
 
 
 @cli.command()

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import yaml
 
@@ -92,10 +92,14 @@ class SettingsFactory:
         """Initialize a new Settings dicitionary."""
         self._settings_dict: SettingsDict = {}
 
-    def build_settings(self, config_path: Optional[Path], cli_flags) -> Settings:
+    def build_settings(
+        self, config_path: Optional[Path], cli_arguments: List[str]
+    ) -> Settings:
         """
         Build new Settings object using parameters from all sources.
 
+        :param config_path: Path to the configuration file
+        :param cli_arguments: List of all CLI configuration options
         :return: Settings object
         """
 
@@ -106,7 +110,7 @@ class SettingsFactory:
         self.load_env_variables()
 
         # Load CLI options
-        self.load_cli_options(cli_flags)
+        self.load_cli_options(cli_arguments)
 
         if not migrations.validate(self._settings_dict):
             raise ValueError(


### PR DESCRIPTION
## Linked Items

Fixes N/A

## Description

This is an improved version of #17 .
Add a basic implementation of cobbler-tftp's CLI:
```
Usage: cobbler-tftp [OPTIONS] COMMAND [ARGS]...

  Cobbler-TFTP - Copyright (c) 2022 The Cobbler Team. (github.com/cobbler)

  Licensed under the terms of the GPLv2.0 license.

Options:
  -h, --help  Show this message and exit.

Commands:
  print-default-config  Print the default application parameters.
  start                 Start the cobbler-tftp server.
  stop                  Stop the cobbler-tftp server daemon if it is running
  version               Check cobbler-tftp version.
```

### TODO:
- [ ] add tests

## Behaviour changes

N/A

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 