### PR TITLE
Implement daemon with logging and TFTP server

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -17,6 +17,8 @@ pycodestyle:
     # https://github.com/psf/black/issues/354#issuecomment-397685631
     - E203
     - W503
+    # Disabled due to the overlap with pylint 
+    - E722
 
 pydocstyle:
   run: true

--- a/src/cobbler_tftp/server/__init__.py
+++ b/src/cobbler_tftp/server/__init__.py
@@ -1,0 +1,39 @@
+"""
+This package contains the actual TFTP server.
+"""
+
+import logging
+import logging.config
+
+from cobbler_tftp.server.tftp import TFTPServer
+from cobbler_tftp.settings import Settings
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
+
+def run_server(application_settings: Settings):
+    """Set up logging, initialize the server and run it."""
+
+    logging_conf = application_settings.logging_conf
+    if logging_conf is None or not logging_conf.exists():
+        logging_conf = files("cobbler_tftp.settings.data").joinpath("logging.conf")
+    logging.config.fileConfig(str(logging_conf))
+    logging.debug("Server starting...")
+    try:
+        address = application_settings.tftp_addr
+        port = application_settings.tftp_port
+        retries = application_settings.tftp_retries
+        timeout = application_settings.tftp_timeout
+        server = TFTPServer(address, port, retries, timeout)
+    except:  # pylint: disable=bare-except
+        logging.exception("Fatal exception while setting up server")
+        return
+    try:
+        server.run()
+    except:  # pylint: disable=bare-except
+        logging.exception("Fatal exception in server")
+    # fbtftp doesn't clean up after exceptions, so we do it here ourselves
+    server._metrics_timer.cancel()  # type: ignore

--- a/src/cobbler_tftp/server/tftp.py
+++ b/src/cobbler_tftp/server/tftp.py
@@ -1,0 +1,88 @@
+"""
+This module contains the main TFTP server class.
+"""
+
+import logging
+
+from fbtftp import BaseHandler, BaseServer, ResponseData
+
+
+class CobblerResponseData(ResponseData):
+    """File-like object representing the response from the TFTP server."""
+
+    def __init__(self):
+        pass
+
+    def read(self, n):
+        return b""
+
+    def size(self):
+        return 0
+
+    def close(self):
+        pass
+
+
+def handler_stats_cb(stats):
+    duration = stats.duration() * 1000
+    logging.info(
+        "Spent %fms processing request for %r from %r",
+        duration,
+        stats.file_path,
+        stats.peer,
+    )
+    logging.info(
+        "Error: %r, sent %d bytes with %d retransmits",
+        stats.error,
+        stats.bytes_sent,
+        stats.retransmits,
+    )
+
+
+def server_stats_cb(stats):
+    """
+    Called by the fbtftp to log server stats. Currently unused.
+    """
+
+
+class CobblerRequestHandler(BaseHandler):
+    """
+    Handles TFTP requests using the Cobbler API.
+    """
+
+    def __init__(self, server_addr, peer, path, options):
+        """
+        Initialize a handler for a specific request.
+
+        :param server_addr: Tuple containing the server address and port.
+        :param peer: Tuple containing the client address and port.
+        :param path: Request file path.
+        :param options: Options requested by the client.
+        """
+        # Future arguments can be handled here
+        super().__init__(server_addr, peer, path, options, handler_stats_cb)
+
+    def get_response_data(self):
+        return CobblerResponseData()
+
+
+class TFTPServer(BaseServer):
+    """
+    Implements a TFTP server for the Cobbler API using the CobblerRequestHandler.
+    """
+
+    def __init__(self, address, port, retries, timeout):
+        """
+        Initialize the TFTP server.
+
+        :param address: IP address to listen on.
+        :param port: UDP Port to listen on.
+        :param retries: Maximum number of retries when sending a packet fails.
+        :param timeout: Timeout for sending packets.
+        """
+        # Future arguments can be handled here
+        self.handler_stats_cb = handler_stats_cb
+        super().__init__(address, port, retries, timeout, server_stats_cb)
+
+    def get_handler(self, server_addr, peer, path, options):
+        return CobblerRequestHandler(server_addr, peer, path, options)

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -26,10 +26,16 @@ class Settings:
         self,
         auto_migrate_settings: bool,
         is_daemon: bool,
+        pid_file_path: Path,
         uri: str,
         username: str,
-        password: Union[str, None],
-        password_file: Union[Path, None],
+        password: Optional[str],
+        password_file: Optional[Path],
+        tftp_addr: str,
+        tftp_port: int,
+        tftp_retries: int,
+        tftp_timeout: int,
+        logging_conf: Optional[Path],
     ) -> None:
         """
         Initialize a new instance of the Settings.
@@ -45,10 +51,16 @@ class Settings:
 
         self.auto_migrate_settings: bool = auto_migrate_settings
         self.is_daemon: bool = is_daemon
+        self.pid_file_path: Path = pid_file_path
         self.uri: str = uri
         self.user: str = username
-        self.__password: Union[str, None] = password
-        self.__password_file: Union[Path, None] = password_file
+        self.tftp_addr: str = tftp_addr
+        self.tftp_port: int = tftp_port
+        self.tftp_retries: int = tftp_retries
+        self.tftp_timeout: int = tftp_timeout
+        self.logging_conf: Optional[Path] = logging_conf
+        self.__password: Optional[str] = password
+        self.__password_file: Optional[Path] = password_file
 
     def __repr__(self):
         """
@@ -126,7 +138,8 @@ class SettingsFactory:
         # Type ignores are necessary as at this point it is not known what value comes from that key.
         auto_migrate_settings: bool = self._settings_dict.get("auto_migrate_settings", False)  # type: ignore
         is_daemon: bool = self._settings_dict.get("is_daemon", False)  # type: ignore
-        cobbler_settings = self._settings_dict.get("cobbler", None)
+        pid_file_path: Path = Path(self._settings_dict.get("pid_file_path", "/run/cobbler-tftp.pid"))  # type: ignore
+        cobbler_settings = self._settings_dict.get("cobbler", {})
         uri: str = cobbler_settings.get("uri", "")  # type: ignore
         username: str = cobbler_settings.get("username", "")  # type: ignore
         password: str = cobbler_settings.get("password", "")  # type: ignore
@@ -134,15 +147,30 @@ class SettingsFactory:
             password_file: Optional[Path] = Path(cobbler_settings.get("password_file", None))  # type: ignore
         else:
             password_file = None
+        tftp_settings = self._settings_dict.get("tftp", None)
+        tftp_addr: str = tftp_settings.get("address", "127.0.0.1")  # type: ignore
+        tftp_port: int = tftp_settings.get("port", 69)  # type: ignore
+        tftp_retries: int = tftp_settings.get("retries", 5)  # type: ignore
+        tftp_timeout: int = tftp_settings.get("timeout", 2)  # type: ignore
+        if self._settings_dict.get("logging_conf", None) is not None:  # type: ignore
+            logging_conf: Optional[Path] = Path(self._settings_dict.get("logging_conf", None))  # type: ignore
+        else:
+            logging_conf = None
 
         # Create and return a new Settings object
         settings = Settings(
             auto_migrate_settings,
             is_daemon,
+            pid_file_path,
             uri,
             username,
             password,
             password_file,
+            tftp_addr,
+            tftp_port,
+            tftp_retries,
+            tftp_timeout,
+            logging_conf,
         )
 
         return settings

--- a/src/cobbler_tftp/settings/data/logging.conf
+++ b/src/cobbler_tftp/settings/data/logging.conf
@@ -1,0 +1,40 @@
+# based on https://github.com/cobbler/cobbler/blob/main/config/cobbler/logging_config.conf
+[loggers]
+keys=root
+
+[handlers]
+keys=FileLogger,stdout
+
+[formatters]
+keys=Logfile,stdout
+
+[logger_root]
+level=DEBUG
+handlers=FileLogger,stdout
+
+[logger_parser]
+level=DEBUG
+handlers=FileLogger
+propagate=1
+qualname=compiler.parser
+
+[handler_stdout]
+class=StreamHandler
+level=INFO
+formatter=stdout
+args=(sys.stdout,)
+
+[handler_FileLogger]
+class=FileHandler
+level=INFO
+formatter=Logfile
+args=('/var/log/cobbler-tftp.log', 'a')
+
+[formatter_Logfile]
+format=[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s
+datefmt=%Y-%m-%dT%H:%M:%S
+class=logging.Formatter
+
+[formatter_stdout]
+format=%(levelname)s | %(message)s
+class=logging.Formatter

--- a/src/cobbler_tftp/settings/data/settings.yml
+++ b/src/cobbler_tftp/settings/data/settings.yml
@@ -3,9 +3,17 @@ schema: 1.0
 auto_migrate_settings: false
 # Run cobbler-tftp as a daemon in the background
 is_daemon: true
+pid_file_path: "/run/cobbler-tftp.pid"
 # Specifications of the cobbler-server
 cobbler:
   uri: "http://localhost/cobbler_api"
   username: "cobbler"
   password: "cobbler"
   # password_file: "/etc/cobbler-tftp/cobbler_password"
+# TFTP server configuration
+tftp:
+  address: "127.0.0.1"
+  port: 69
+  retries: 5
+  timeout: 2
+logging_conf: "/etc/cobbler-tftp/logging.conf"

--- a/src/cobbler_tftp/settings/migrations/__init__.py
+++ b/src/cobbler_tftp/settings/migrations/__init__.py
@@ -131,9 +131,9 @@ def __validate_module(name: ModuleType) -> bool:
     """
     # noqa for these lines because we can't use the custom types to check this.
     module_methods = {
-        "validate": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[str,pathlib.Path]]]])->bool",  # noqa
-        "normalize": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[str,pathlib.Path]]]])->Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[str,pathlib.Path]]]]",  # noqa
-        "migrate": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[str,pathlib.Path]]]])->Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[str,pathlib.Path]]]]",  # noqa
+        "validate": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[int,str,pathlib.Path]]]])->bool",  # noqa
+        "normalize": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[int,str,pathlib.Path]]]])->Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[int,str,pathlib.Path]]]]",  # noqa
+        "migrate": "(settings_dict:Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[int,str,pathlib.Path]]]])->Dict[str,Union[float,bool,str,pathlib.Path,Dict[str,Union[int,str,pathlib.Path]]]]",  # noqa
     }
 
     for key, value in module_methods.items():

--- a/src/cobbler_tftp/settings/migrations/v1_0.py
+++ b/src/cobbler_tftp/settings/migrations/v1_0.py
@@ -11,11 +11,19 @@ settings_schema: Schema = Schema(
         Optional("schema"): float,
         Optional("auto_migrate_settings"): bool,
         Optional("is_daemon"): bool,
+        Optional("pid_file_path"): str,
         Optional("cobbler"): {
             Optional("uri"): str,
             Optional("username"): str,
             Optional(Or("password", "password_file", only_one=True)): Or(str, Path),
         },
+        Optional("tftp"): {
+            Optional("address"): str,
+            Optional("port"): int,
+            Optional("retries"): int,
+            Optional("timeout"): int,
+        },
+        Optional("logging_conf"): str,
     }
 )
 

--- a/src/cobbler_tftp/types/__init__.py
+++ b/src/cobbler_tftp/types/__init__.py
@@ -5,4 +5,6 @@ from typing import Dict, Union
 
 # Dictionary type for configuration parameters
 # if this type changes: changes __valdiate_module function in migrations/__init__.py
-SettingsDict = Dict[str, Union[float, bool, str, Path, Dict[str, Union[str, Path]]]]
+SettingsDict = Dict[
+    str, Union[float, bool, str, Path, Dict[str, Union[int, str, Path]]]
+]

--- a/tests/test_data/valid_config.yml
+++ b/tests/test_data/valid_config.yml
@@ -5,3 +5,8 @@ cobbler:
   uri: 'http://testmachine.testnetwork.com/api'
   username: 'cobbler'
   password_file: 'tests/test_data/password_file'
+tftp:
+  address: '0.0.0.0'
+  port: 1969
+  retries: 10
+  timeout: 3

--- a/tests/unittests/application_settings/conftest.py
+++ b/tests/unittests/application_settings/conftest.py
@@ -1,6 +1,8 @@
 """
 This module implements all necessary fixtures for running the unittests using pytests. They are automaticall discovered.
 """
+from pathlib import Path
+
 import pytest
 
 from cobbler_tftp.types import SettingsDict
@@ -18,11 +20,19 @@ def fake_settings_dict() -> SettingsDict:
         "schema": 1.0,
         "auto_migrate_settings": True,
         "is_daemon": True,
+        "pid_file_path": Path("/run/cobbler-tftp.pid"),
         "cobbler": {
             "uri": "http://localhost/cobbler_api",
             "username": "cobbler",
             "password": "cobbler",
         },
+        "tftp": {
+            "addr": "127.0.0.1",
+            "port": 69,
+            "timeout": 2,
+            "retries": 5,
+        },
+        "logging_conf": "/etc/cobbler-tftp/logging.conf",
     }
     return fake_settings_dict
 

--- a/tests/unittests/application_settings/test_settings.py
+++ b/tests/unittests/application_settings/test_settings.py
@@ -17,6 +17,20 @@ def settings_factory():
     return SettingsFactory()
 
 
+def assert_default_settings(settings):
+    assert settings.auto_migrate_settings is False
+    assert settings.is_daemon is True
+    assert str(settings.pid_file_path) == "/run/cobbler-tftp.pid"
+    assert settings.uri == "http://localhost/cobbler_api"
+    assert settings.user == "cobbler"
+    assert settings.password == "cobbler"
+    assert settings.tftp_addr == "127.0.0.1"
+    assert settings.tftp_port == 69
+    assert settings.tftp_retries == 5
+    assert settings.tftp_timeout == 2
+    assert str(settings.logging_conf) == "/etc/cobbler-tftp/logging.conf"
+
+
 def test_build_settings_with_default_config_file(
     settings_factory: SettingsFactory, mocker
 ):
@@ -31,11 +45,7 @@ def test_build_settings_with_default_config_file(
 
     # Assert that the expected values are set in the Settings object
     assert isinstance(settings, Settings)
-    assert settings.auto_migrate_settings is False
-    assert settings.is_daemon is True
-    assert settings.uri == "http://localhost/cobbler_api"
-    assert settings.user == "cobbler"
-    assert settings.password == "cobbler"
+    assert_default_settings(settings)
 
 
 def test_build_settings_with_valid_config_file(
@@ -50,6 +60,10 @@ def test_build_settings_with_valid_config_file(
     assert settings.uri == "http://testmachine.testnetwork.com/api"
     assert settings.user == "cobbler"
     assert settings.password == "password"
+    assert settings.tftp_addr == "0.0.0.0"  # nosec
+    assert settings.tftp_port == 1969
+    assert settings.tftp_retries == 10
+    assert settings.tftp_timeout == 3
 
 
 def test_build_settings_with_invalid_config_file(
@@ -89,8 +103,4 @@ def test_build_settings_with_missing_config_file(
     captured_message = capsys.readouterr()
     assert captured_message.out == expected_message
     assert isinstance(settings, Settings)
-    assert settings.auto_migrate_settings is False
-    assert settings.is_daemon is True
-    assert settings.uri == "http://localhost/cobbler_api"
-    assert settings.user == "cobbler"
-    assert settings.password == "cobbler"
+    assert_default_settings(settings)


### PR DESCRIPTION
## Linked Items

Fixes #21

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Implement the start and stop commands, add logging and implement a TFTP server using fbtftp which currently returns empty files.

### TODO:
- [x] Make the daemon exit on the first SIGTERM/SIGINT. It currently doesn't because some threads don't exit.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
