### PR TITLE
Fix customization of settings via CLI and environment variables

### DIFF
--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -65,7 +65,7 @@ def cli(ctx):
     multiple=True,
     help="""Set custom settings in format:\n
     <PARENT_YAML_KEY>.<CHILD_YAML_KEY>.<...>.<KEY_NAME>=<VALUE>.\n
-    Your settings must use single quotes. If a single quote appears within a value it must be escaped.""",
+    The value is parsed as YAML. Quotes around the value are recommended for strings.""",
 )
 def start(
     daemon: Optional[bool],

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -256,7 +256,8 @@ class SettingsFactory:
         :param daemon: If the application should be run in the background as a daemon or not.
         :param enable_automigration: Whether to enable the automigration or not.
         :param settings: List of custom settings which can be entered manually.
-                         Each entry has the format: ``<PARENT_YAML_KEY>.<CHILD_YAML_KEY>.<...>.<KEY_NAME>=<VALUE>``
+                         Each entry has the format: ``<PARENT_YAML_KEY>.<CHILD_YAML_KEY>.<...>.<KEY_NAME>=<VALUE>``,
+                         where VALUE is parsed as a YAML value.
         :return _settings_dict: Settings dictionary.
         """
 
@@ -271,12 +272,13 @@ class SettingsFactory:
             if "." not in option_list[0]:
                 self._settings_dict.update({option_list[0]: option_list[1]})
             else:
-                parent = option_list[0].split(".")
+                key_path = option_list[0].split(".")
+                key_path.reverse()
 
-                setting_to_update = {parent[-1]: option_list[1]}
+                setting_to_update = yaml.safe_load(option_list[1])
 
-                for key in range(len(parent), 0, -1):
-                    setting_to_update = {parent[key]: setting_to_update}
+                for key in key_path:
+                    setting_to_update = {key: setting_to_update}
 
                 self._settings_dict.update(setting_to_update)  # type: ignore
 

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -220,21 +220,19 @@ class SettingsFactory:
             return self._settings_dict
 
         for variable in cobbler_keys:
-            key_path = variable.split("__")
-            key_to_update = key_path[-1]
+            key_path = variable.split("__")[1:]
+            key_path.reverse()
+            key_to_update = key_path[0]
 
-            if len(key_path) == 2:
-                try:
-                    self._settings_dict.update(
-                        {key_to_update.lower(): str(os.environ[variable])}
-                    )
-                except KeyError as exc:
-                    print(exc)
+            if len(key_path) == 1:
+                self._settings_dict.update(
+                    {key_to_update.lower(): yaml.safe_load(os.environ[variable])}
+                )
             else:
-                setting_to_update = {key_to_update.lower(): str(os.environ[variable])}
+                setting_to_update = yaml.safe_load(os.environ[variable])
 
-                for pos in range(len(key_path) - 2, 1, -1):
-                    setting_to_update = {key_path[pos]: setting_to_update}
+                for key in key_path:
+                    setting_to_update = {key.lower(): setting_to_update}
 
                 self._settings_dict.update(setting_to_update)  # type: ignore
 

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -183,12 +183,8 @@ class SettingsFactory:
         :return _settings_dict: Dictionary containing all settings from the settings.yml file
         """
 
-        config_file = str(config_path).rsplit("/", maxsplit=1)[-1]
-        config_pure_path = Path(str(config_path).replace(config_file, ""))
-        config_import_path = str(config_pure_path).replace("/", ".", -1)
-
-        if not config_path or config_path == "" or not Path.exists(config_path):
-            if config_path and not Path.exists(config_path):  # type: ignore
+        if config_path is None or not Path.exists(config_path):
+            if config_path is not None:
                 # Prompt the user that no configuration file could be found and the default will be used
                 print(
                     f"Warning: No configuration file found at {config_path}! Using default configuration file..."
@@ -202,11 +198,9 @@ class SettingsFactory:
                 self._settings_dict = yaml.safe_load(config_file_content)
             except yaml.YAMLError:
                 print(f"Error: No valid configuration file found at {config_path}!")
-        elif config_path and Path.exists(config_path):
+        elif config_path is not None:
             try:
-                config_file_content = (
-                    files(config_import_path).joinpath(config_file).read_text("utf-8")  # type: ignore
-                )
+                config_file_content = config_path.read_text(encoding="UTF-8")
                 self._settings_dict = yaml.safe_load(config_file_content)
             except yaml.YAMLError:
                 print(f"Error: No valid configuration file found at {config_path}!")

--- a/tests/unittests/application_settings/test_settings.py
+++ b/tests/unittests/application_settings/test_settings.py
@@ -31,6 +31,18 @@ def assert_default_settings(settings):
     assert str(settings.logging_conf) == "/etc/cobbler-tftp/logging.conf"
 
 
+def assert_customized_settings(settings):
+    assert settings.auto_migrate_settings is True
+    assert settings.is_daemon is False
+    assert settings.uri == "http://testmachine.testnetwork.com/api"
+    assert settings.user == "cobbler"
+    assert settings.password == "password"
+    assert settings.tftp_addr == "0.0.0.0"  # nosec
+    assert settings.tftp_port == 1969
+    assert settings.tftp_retries == 10
+    assert settings.tftp_timeout == 3
+
+
 def test_build_settings_with_default_config_file(
     settings_factory: SettingsFactory, mocker
 ):
@@ -55,15 +67,17 @@ def test_build_settings_with_valid_config_file(
     settings = settings_factory.build_settings(valid_file_path)
 
     assert isinstance(settings, Settings)
-    assert settings.auto_migrate_settings is True
-    assert settings.is_daemon is False
-    assert settings.uri == "http://testmachine.testnetwork.com/api"
-    assert settings.user == "cobbler"
-    assert settings.password == "password"
-    assert settings.tftp_addr == "0.0.0.0"  # nosec
-    assert settings.tftp_port == 1969
-    assert settings.tftp_retries == 10
-    assert settings.tftp_timeout == 3
+    assert_customized_settings(settings)
+
+
+def test_build_settings_with_absolute_config_path(
+    settings_factory: SettingsFactory, mocker
+):
+    absolute_path = Path("tests/test_data/valid_config.yml").absolute()
+    settings = settings_factory.build_settings(absolute_path)
+
+    assert isinstance(settings, Settings)
+    assert_customized_settings(settings)
 
 
 def test_build_settings_with_invalid_config_file(

--- a/tests/unittests/application_settings/test_settings.py
+++ b/tests/unittests/application_settings/test_settings.py
@@ -118,3 +118,21 @@ def test_build_settings_with_missing_config_file(
     assert captured_message.out == expected_message
     assert isinstance(settings, Settings)
     assert_default_settings(settings)
+
+
+def test_build_settings_with_cli_args(settings_factory: SettingsFactory):
+    cli_settings = ["tftp.address=1.2.3.4"]
+
+    settings = settings_factory.build_settings(None, cli_arguments=cli_settings)
+
+    assert isinstance(settings, Settings)
+    assert settings.tftp_addr == "1.2.3.4"
+
+
+def test_build_settings_with_integer_cli_args(settings_factory: SettingsFactory):
+    cli_settings = ["tftp.port=1969"]
+
+    settings = settings_factory.build_settings(None, cli_arguments=cli_settings)
+
+    assert isinstance(settings, Settings)
+    assert settings.tftp_port == 1969

--- a/tests/unittests/application_settings/test_settings.py
+++ b/tests/unittests/application_settings/test_settings.py
@@ -2,7 +2,9 @@
 Tests for the application settings module.
 """
 
+import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -133,6 +135,22 @@ def test_build_settings_with_integer_cli_args(settings_factory: SettingsFactory)
     cli_settings = ["tftp.port=1969"]
 
     settings = settings_factory.build_settings(None, cli_arguments=cli_settings)
+
+    assert isinstance(settings, Settings)
+    assert settings.tftp_port == 1969
+
+
+@mock.patch.dict(os.environ, {"COBBLER_TFTP__TFTP__ADDRESS": "1.2.3.4"})
+def test_build_settings_with_env_vars(settings_factory: SettingsFactory):
+    settings = settings_factory.build_settings(None)
+
+    assert isinstance(settings, Settings)
+    assert settings.tftp_addr == "1.2.3.4"
+
+
+@mock.patch.dict(os.environ, {"COBBLER_TFTP__TFTP__PORT": "1969"})
+def test_build_settings_with_integer_env_vars(settings_factory: SettingsFactory):
+    settings = settings_factory.build_settings(None)
 
     assert isinstance(settings, Settings)
     assert settings.tftp_port == 1969


### PR DESCRIPTION
## Linked Items

Fixes #22.

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Fix the `load_env_variables` and `load_cli_options` methods of SettingsFactory and make `load_config_file` work properly with absolute config file paths. To support non-string options, the values specified in environment variables and CLI options are parsed with `yaml.safe_load`, which may require adding quotes around strings.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
