### PR TITLE
Implement fetching files from XMLRPC or static directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/cobbler-tftp.spec
+++ b/cobbler-tftp.spec
@@ -1,0 +1,97 @@
+#
+# spec file for package cobbler-tftp
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+%if 0%{?suse_version} > 1500
+%bcond_without libalternatives
+%else
+%bcond_with libalternatives
+%endif
+
+%define python_package_name cobbler_tftp
+
+%{?sle15_python_module_pythons}
+Name:           cobbler-tftp
+Version:        0.0.0+git.1705312236.c60217f
+Release:        0
+Summary:        The TFTP server daemon for Cobbler
+License:        GPL-2.0-or-later
+URL:            https://github.com/cobbler/cobbler-tftp
+Source0:        %{name}-%{version}.tar.gz
+
+%if 0%{?suse_version}
+BuildRequires:  python-rpm-macros
+%endif
+
+BuildRequires:  fdupes
+BuildRequires:  git
+BuildRequires:  %{python_module pip}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module setuptools_scm}
+BuildRequires:  %{python_module wheel}
+
+Requires:       python3-fbtftp
+Requires:       python3-python-daemon
+Requires:       python3-PyYAML
+Requires:       python3-click
+Requires:       python3-importlib-metadata
+Requires:       python3-importlib-resources
+Requires:       python3-schema
+%if %{with libalternatives}
+Requires:       alts
+BuildRequires:  alts
+%else
+Requires(post):   update-alternatives
+Requires(postun): update-alternatives
+%endif
+BuildArch:      noarch
+%python_subpackages
+
+%description
+Cobbler-TFTP is a lightweight CLI application written in Python that serves as a stateless TFTP server.
+It seamlessly integrates with Cobbler to generate and serve boot configuration files dynamically to managed machines.
+
+%prep
+%autosetup
+
+%build
+cp -r %{_sourcedir}/cobbler-tftp-%{version}/.git %{_builddir}/cobbler-tftp-%{version}
+%pyproject_wheel
+
+%install
+%pyproject_install
+%python_clone -a %{buildroot}%{_bindir}/cobbler-tftp
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
+
+%pre
+%python_libalternatives_reset_alternative cobbler-tftp
+
+%post
+%python_install_alternative cobbler-tftp
+
+%postun
+%python_uninstall_alternative cobbler-tftp
+
+%files %{python_files}
+%license LICENSE
+%doc README.md
+%python_alternative %{_bindir}/cobbler-tftp
+%{_bindir}/cobbler-tftp-%{python_bin_suffix}
+%{python_sitelib}/%{python_package_name}
+%{python_sitelib}/%{python_package_name}-*.dist-info
+
+%changelog
+

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -4,7 +4,7 @@ Cobbler-tftp will be managable as a command-line service.
 
 import os
 from pathlib import Path
-from signal import SIGTERM
+from signal import SIGCHLD, SIGTERM
 from typing import List, Optional
 
 import click
@@ -87,7 +87,7 @@ def start(
     )
     if application_settings.is_daemon:
         click.echo("Starting daemon...")
-        with DaemonContext():
+        with DaemonContext(signal_map={SIGCHLD: None}):
             # All previously open file descriptors are invalid now.
             # Files and connections needed for the daemon should be opened
             # in run_server or listed in the files_preserve option

--- a/src/cobbler_tftp/server/__init__.py
+++ b/src/cobbler_tftp/server/__init__.py
@@ -23,11 +23,7 @@ def run_server(application_settings: Settings):
     logging.config.fileConfig(str(logging_conf))
     logging.debug("Server starting...")
     try:
-        address = application_settings.tftp_addr
-        port = application_settings.tftp_port
-        retries = application_settings.tftp_retries
-        timeout = application_settings.tftp_timeout
-        server = TFTPServer(address, port, retries, timeout)
+        server = TFTPServer(application_settings)
     except:  # pylint: disable=bare-except
         logging.exception("Fatal exception while setting up server")
         return
@@ -35,5 +31,4 @@ def run_server(application_settings: Settings):
         server.run()
     except:  # pylint: disable=bare-except
         logging.exception("Fatal exception in server")
-    # fbtftp doesn't clean up after exceptions, so we do it here ourselves
-    server._metrics_timer.cancel()  # type: ignore
+    server.cleanup()

--- a/src/cobbler_tftp/settings/data/settings.yml
+++ b/src/cobbler_tftp/settings/data/settings.yml
@@ -10,10 +10,18 @@ cobbler:
   username: "cobbler"
   password: "cobbler"
   # password_file: "/etc/cobbler-tftp/cobbler_password"
+  # Time before requesting a new token, in seconds. To avoid problems, set
+  # this to a lower value than the token expiration time.
+  token_refresh_interval: 1800
+# Chunk size used for fetching files from Cobbler.
+# Lower values result in slower transfers, higher values increase memory
+# consumption. Extremely large values may cause TFTP timeouts.
+prefetch_size: 4096
 # TFTP server configuration
 tftp:
   address: "127.0.0.1"
   port: 69
   retries: 5
   timeout: 2
+  static_fallback_dir: "/srv/tftpboot"
 logging_conf: "/etc/cobbler-tftp/logging.conf"

--- a/src/cobbler_tftp/settings/migrations/v1_0.py
+++ b/src/cobbler_tftp/settings/migrations/v1_0.py
@@ -16,12 +16,15 @@ settings_schema: Schema = Schema(
             Optional("uri"): str,
             Optional("username"): str,
             Optional(Or("password", "password_file", only_one=True)): Or(str, Path),
+            Optional("token_refresh_interval"): int,
         },
+        Optional("prefetch_size"): int,
         Optional("tftp"): {
             Optional("address"): str,
             Optional("port"): int,
             Optional("retries"): int,
             Optional("timeout"): int,
+            Optional("static_fallback_dir"): str,
         },
         Optional("logging_conf"): str,
     }


### PR DESCRIPTION
## Linked Items

Fixes #6

## Description

Implement the functionality behind the TFTP server by requesting a file from Cobbler via XMLRPC. If Cobbler cannot return a file at the requested path, cobbler-tftp will fall back to serving files from a **local** static directory.

This is much slower than a normal TFTP server: on my laptop, it can handle about 25 requests per second but is too slow for 30.

# TODO
- [X] Implement the get_tftp_file endpoint in Cobbler: https://github.com/cobbler/cobbler/pull/3549
- [x] Use the configured username and password when accessing the Cobbler API
- [X] Ensure that the fallback does not access any files outside the static directory (e.g. via .. in the path)

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
