### PR TITLE
Add setup command and systemd service

### DIFF
--- a/src/cobbler_tftp/settings/data/cobbler-tftp.service
+++ b/src/cobbler_tftp/settings/data/cobbler-tftp.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cobbler TFTP Server
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/cobbler-tftp start --no-daemon
+PrivateTmp=yes
+Type=exec
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cobbler_tftp/utils.py
+++ b/src/cobbler_tftp/utils.py
@@ -1,0 +1,35 @@
+"""
+Various utility functions for cobbler-tftp
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+try:
+    from importlib.abc import Traversable
+except ImportError:
+    from importlib_resources.abc import Traversable
+
+
+def copy_file(
+    src_dir: Traversable,
+    dst_dir: Path,
+    name: str,
+    patch: Optional[List[Tuple[str, str]]] = None,
+):
+    """
+    Copy a file to a different directory, preserving the name and
+    possibly replacing strings in it.
+
+    :param src_dir: Directory that contains the file to copy.
+    :param dst_dir: Directory to copy the file into.
+    :param name: Name of the file (in both directories).
+    :param patch: List of (old, new) strings to replace in the file.
+    """
+    src = src_dir / name
+    dst = dst_dir / name
+    contents: bytes = src.read_bytes()  # type: ignore
+    if patch is not None:
+        for old, new in patch:
+            contents = contents.replace(old.encode("UTF-8"), new.encode("UTF-8"))
+    dst.write_bytes(contents)


### PR DESCRIPTION
## Linked Items

Fixes #25

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Add a command for installing configuration files and the systemd service file. Run the command automatically when building an RPM.

## Behaviour changes

Old: Configuration was loaded from the python package and the daemon had to be started manually.

New: Configuration is installed into and loaded from /etc by default and the daemon can be managed via systemd.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
