### PR TITLE
Add OCI containers

### DIFF
--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -1,0 +1,43 @@
+# This workflow builds and pushes the docker image for Cobbler-TFTP to "ghcr.io".
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        # https://github.com/docker/login-action
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        # https://github.com/docker/metadata-action
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/production/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,9 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - name: Check files using the black formatter
-          uses: rickstaa/action-black@v1
-          id: action_black
+          uses: psf/black@stable
           with:
-            black_args: ". --check --safe --verbose"
+            options: "--check --safe --verbose"
             version: "22.3.0"
   pyright:
       name: pyright

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update package cache
         run: sudo apt-get -yq update
       - name: Install Deps for installing project
-        run: pip install wheel
+        run: pip install wheel setuptools
       - name: Install Deps with pip
         run: pip install .
       - name: Install pypa/build

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,5 @@ formats: all
 python:
   install:
     - requirements: docs/requirements.rtd.txt
+    - method: pip
+      path: .

--- a/changelog.d/4.added
+++ b/changelog.d/4.added
@@ -1,0 +1,1 @@
+Add dockerfiles for image based deployments

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -1,0 +1,30 @@
+# vim: ft=dockerfile
+
+FROM opensuse/tumbleweed
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.example
+LABEL org.opencontainers.image.title="cobbler-tftp"
+LABEL org.opencontainers.image.description="This image runs the (nearly) stateless Cobbler TFTP server."
+LABEL org.opencontainers.image.version="dev.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/systemsmanagement/cobbler/dev/cobbler-tftp:dev.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
+# ENV Variables we are using.
+ENV container docker
+
+# Custom repository
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/openSUSE_Tumbleweed/ "Cobbler 3.4.x release project" \
+    && zypper --gpg-auto-import-keys refresh
+
+# Dependencies
+RUN zypper in -y git \
+    python3-devel \
+    python3-pip \
+    && zypper clean
+
+WORKDIR /code
+EXPOSE 69/UDP
+CMD ["/code/docker/develop/entrypoint.sh"]

--- a/docker/develop/entrypoint.sh
+++ b/docker/develop/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+pip3 install --break-system-packages -e .
+cobbler-tftp start --no-daemon

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -26,7 +26,7 @@ RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobb
     && zypper --gpg-auto-import-keys refresh
 
 # Dev Dependencies
-RUN zypper in cobbler-tftp \
+RUN zypper in -y cobbler-tftp \
     && zypper clean
 
 EXPOSE 69/UDP

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,0 +1,33 @@
+# vim: ft=dockerfile
+# Define the names/tags of the container
+#!BuildTag: cobbler-test-github:release33 cobbler-test-github:release33.%RELEASE%
+
+# We are using https://github.com/hadolint/hadolint to lint our Dockerfile.
+# We don't want to version pin our dependencies for testing. Always retrieve what is up to date.
+# hadolint global ignore=DL3037
+
+FROM opensuse/leap:15.6
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.example
+LABEL org.opencontainers.image.title="cobbler-tftp"
+LABEL org.opencontainers.image.description="This image runs the (nearly) stateless Cobbler TFTP server."
+LABEL org.opencontainers.image.version="release34.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/systemsmanagement/cobbler/release34/cobbler-tftp:release34.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
+# ENV Variables we are using.
+ENV container docker
+
+# Custom repository
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/15.6/ "Cobbler 3.4.x release project" \
+    && zypper --gpg-auto-import-keys refresh
+
+# Dev Dependencies
+RUN zypper in cobbler-tftp \
+    && zypper clean
+
+EXPOSE 69/UDP
+CMD ["cobbler-tftp", "--no-daemon"]

--- a/docker/rolling/Dockerfile
+++ b/docker/rolling/Dockerfile
@@ -1,0 +1,33 @@
+# vim: ft=dockerfile
+# Define the names/tags of the container
+#!BuildTag: cobbler-test-github:release33 cobbler-test-github:release33.%RELEASE%
+
+# We are using https://github.com/hadolint/hadolint to lint our Dockerfile.
+# We don't want to version pin our dependencies for testing. Always retrieve what is up to date.
+# hadolint global ignore=DL3037
+
+FROM opensuse/tumbleweed:latest
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.example
+LABEL org.opencontainers.image.title="cobbler-tftp"
+LABEL org.opencontainers.image.description="This image runs the (nearly) stateless Cobbler TFTP server."
+LABEL org.opencontainers.image.version="rolling.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/systemsmanagement/cobbler/containers/cobbler-tftp:rolling.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
+# ENV Variables we are using.
+ENV container docker
+
+# Custom repository
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/openSUSE_Tumbleweed/ "Cobbler 3.4.x release project" \
+    && zypper --gpg-auto-import-keys refresh
+
+# Dependencies
+RUN zypper in -y cobbler-tftp \
+    && zypper clean
+
+EXPOSE 69/UDP
+CMD ["cobbler-tftp", "start", "--no-daemon"]

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -9,26 +9,25 @@ from signal import SIGCHLD, SIGTERM
 from typing import List, Optional
 
 import click
-import yaml
-from daemon import DaemonContext
+from daemon import DaemonContext  # type: ignore
 
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:  # use backport for Python versions older than 3.8
-    import importlib_metadata
+    import importlib_metadata  # type: ignore
 
 try:
     from importlib.resources import files
 except ImportError:
-    from importlib_resources import files
+    from importlib_resources import files  # type: ignore
 
 from cobbler_tftp.server import run_server
 from cobbler_tftp.settings import SettingsFactory
-from cobbler_tftp.utils import copy_file
+from cobbler_tftp.utils import copy_file  # type: ignore
 
 try:
-    __version__ = importlib_metadata.version("cobbler_tftp")
-except importlib_metadata.PackageNotFoundError:
+    __version__ = importlib_metadata.version("cobbler_tftp")  # type: ignore
+except importlib_metadata.PackageNotFoundError:  # type: ignore
     __version__ = "unknown (not installed)"
 
 _context_settings = dict(help_option_names=["-h", "--help"])
@@ -36,7 +35,7 @@ _context_settings = dict(help_option_names=["-h", "--help"])
 
 @click.group(context_settings=_context_settings, invoke_without_command=True)
 @click.pass_context
-def cli(ctx):
+def cli(ctx: click.Context):
     """
     Cobbler-TFTP - Copyright (c) 2022 The Cobbler Team. (github.com/cobbler)\n
     Licensed under the terms of the GPLv2.0 license.
@@ -203,7 +202,7 @@ def setup(
         config_dir = str(config_path.absolute())
     try:
         config_path.mkdir(parents=True, exist_ok=True)
-        source_path = files("cobbler_tftp.settings.data")
+        source_path = files("cobbler_tftp.settings.data")  # type: ignore
         if systemd:
             systemd_path.mkdir(parents=True, exist_ok=True)
             copy_file(source_path, systemd_path, "cobbler-tftp.service")

--- a/src/cobbler_tftp/exceptions/settings_exceptions.py
+++ b/src/cobbler_tftp/exceptions/settings_exceptions.py
@@ -1,5 +1,7 @@
 """Custom exceptions for cobbler-tftp's settings module."""
 
+from typing import Optional
+
 
 class CobblerTftpSettingsException(Exception):
     """Generic cobbler-tftp exception."""
@@ -14,8 +16,8 @@ class CobblerTftpMissingConfigParameterException(KeyError):
 
     def __init__(
         self,
-        message="MissingConfigParameterException: Application settings missing required parameter!",
-        parameter: str = "NONE",
+        message: str = "MissingConfigParameterException: Application settings missing required parameter!",
+        parameter: Optional[str] = "NONE",
     ):
         """Create custom exception to raise when a specific config parameter is missing for the application settings."""
         if parameter is None or parameter == "NONE":

--- a/src/cobbler_tftp/server/__init__.py
+++ b/src/cobbler_tftp/server/__init__.py
@@ -11,7 +11,7 @@ from cobbler_tftp.settings import Settings
 try:
     from importlib.resources import files
 except ImportError:
-    from importlib_resources import files
+    from importlib_resources import files  # type: ignore
 
 
 def run_server(application_settings: Settings):
@@ -19,8 +19,8 @@ def run_server(application_settings: Settings):
 
     logging_conf = application_settings.logging_conf
     if logging_conf is None or not logging_conf.exists():
-        logging_conf = files("cobbler_tftp.settings.data").joinpath("logging.conf")
-    logging.config.fileConfig(str(logging_conf))
+        logging_conf = files("cobbler_tftp.settings.data").joinpath("logging.conf")  # type: ignore
+    logging.config.fileConfig(str(logging_conf))  # type: ignore
     logging.debug("Server starting...")
     try:
         server = TFTPServer(application_settings)

--- a/src/cobbler_tftp/settings/__init__.py
+++ b/src/cobbler_tftp/settings/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import yaml
 
@@ -207,15 +207,15 @@ class SettingsFactory:
                     f"Warning: No configuration file found at {config_path}! Using default configuration file..."
                 )
             try:
-                config_file_content = (
-                    files("cobbler_tftp.settings.data")
+                config_file_content: str = (  # type: ignore
+                    files("cobbler_tftp.settings.data")  # type: ignore
                     .joinpath("settings.yml")
                     .read_text(encoding="UTF-8")  # type: ignore
                 )
-                self._settings_dict = yaml.safe_load(config_file_content)
+                self._settings_dict = yaml.safe_load(config_file_content)  # type: ignore
             except yaml.YAMLError:
                 print(f"Error: No valid configuration file found at {config_path}!")
-        elif config_path is not None:
+        elif config_path is not None:  # type: ignore
             try:
                 config_file_content = config_path.read_text(encoding="UTF-8")
                 self._settings_dict = yaml.safe_load(config_file_content)

--- a/src/cobbler_tftp/settings/migrations/v1_0.py
+++ b/src/cobbler_tftp/settings/migrations/v1_0.py
@@ -2,7 +2,13 @@
 
 from pathlib import Path
 
-from schema import Optional, Or, Schema, SchemaError, SchemaWrongKeyError
+from schema import (  # type: ignore[reportMissingTypeStubs]
+    Optional,
+    Or,
+    Schema,
+    SchemaError,
+    SchemaWrongKeyError,
+)
 
 from cobbler_tftp.types import SettingsDict
 
@@ -15,7 +21,7 @@ settings_schema: Schema = Schema(
         Optional("cobbler"): {
             Optional("uri"): str,
             Optional("username"): str,
-            Optional(Or("password", "password_file", only_one=True)): Or(str, Path),
+            Optional(Or("password", "password_file", only_one=True)): Or(str, Path),  # type: ignore[reportArgumentType]
             Optional("token_refresh_interval"): int,
         },
         Optional("prefetch_size"): int,
@@ -38,7 +44,7 @@ def validate(settings_dict: SettingsDict) -> bool:
     :param settings_dict: The dictionary of configuration parameters to validate
     :return bool: True/False depending on whether the dicts match or not
     """
-    if settings_dict == {} or settings_dict is None:
+    if settings_dict == {} or settings_dict is None:  # type: ignore[reportUncessaryComparison]
         return False
 
     try:

--- a/src/cobbler_tftp/settings/migrations/v1_0.py
+++ b/src/cobbler_tftp/settings/migrations/v1_0.py
@@ -21,7 +21,10 @@ settings_schema: Schema = Schema(
         Optional("cobbler"): {
             Optional("uri"): str,
             Optional("username"): str,
-            Optional(Or("password", "password_file", only_one=True)): Or(str, Path),  # type: ignore[reportArgumentType]
+            # We cannot use only_one since python-schema is only available in 0.6.7 in SLES 15.6
+            # Optional(Or("password", "password_file", only_one=True)): Or(str, Path),  # type: ignore[reportArgumentType]
+            Optional("password"): Or(str, Path),  # type: ignore[reportArgumentType]
+            Optional("password_file"): Or(str, Path),  # type: ignore[reportArgumentType]
             Optional("token_refresh_interval"): int,
         },
         Optional("prefetch_size"): int,

--- a/src/cobbler_tftp/utils.py
+++ b/src/cobbler_tftp/utils.py
@@ -8,11 +8,11 @@ from typing import List, Optional, Tuple
 try:
     from importlib.abc import Traversable
 except ImportError:
-    from importlib_resources.abc import Traversable
+    from importlib_resources.abc import Traversable  # type: ignore
 
 
 def copy_file(
-    src_dir: Traversable,
+    src_dir: Traversable,  # type: ignore
     dst_dir: Path,
     name: str,
     patch: Optional[List[Tuple[str, str]]] = None,
@@ -26,10 +26,10 @@ def copy_file(
     :param name: Name of the file (in both directories).
     :param patch: List of (old, new) strings to replace in the file.
     """
-    src = src_dir / name
+    src = src_dir / name  # type: ignore
     dst = dst_dir / name
     contents: bytes = src.read_bytes()  # type: ignore
     if patch is not None:
         for old, new in patch:
-            contents = contents.replace(old.encode("UTF-8"), new.encode("UTF-8"))
-    dst.write_bytes(contents)
+            contents = contents.replace(old.encode("UTF-8"), new.encode("UTF-8"))  # type: ignore
+    dst.write_bytes(contents)  # type: ignore

--- a/tests/unittests/application_settings/conftest.py
+++ b/tests/unittests/application_settings/conftest.py
@@ -1,6 +1,7 @@
 """
 This module implements all necessary fixtures for running the unittests using pytests. They are automaticall discovered.
 """
+
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,7 @@ from cobbler_tftp.types import SettingsDict
 try:
     import importlib.resources as importlib_resources
 except ImportError:
-    import importlib_resources as importlib_resources  # type: ignore
+    import importlib_resources  # type: ignore
 
 
 @pytest.fixture
@@ -38,8 +39,9 @@ def fake_settings_dict() -> SettingsDict:
 
 
 @pytest.fixture
-def settings_path():
-    with importlib_resources.path(
+def settings_path() -> Path:
+    # pyright cannot work with our try-except import for older Python versions
+    with importlib_resources.path(  # type: ignore[reportUnkownMemberType]
         "src.cobbler_tftp.settings.data", "settings.yml"
-    ) as settings_path:
-        return settings_path
+    ) as settings_path:  # type: ignore[reportUnkownVariableType]
+        return settings_path  # type: ignore[reportUnkownVariableType]

--- a/tests/unittests/application_settings/test_migrations.py
+++ b/tests/unittests/application_settings/test_migrations.py
@@ -2,12 +2,13 @@
 Tests for the settings schemas in the migrations module.
 """
 
+import pathlib
 from pathlib import Path
-from typing import List
+from typing import Any, List, Optional
 
 import pytest
 import pytest_mock
-from schema import Schema
+from schema import Schema  # type: ignore[reportMissingTypeStubs]
 
 import cobbler_tftp.settings.migrations as migrations
 from cobbler_tftp.types import SettingsDict
@@ -36,7 +37,7 @@ def reset_version_list():
     migrations.discover_migrations()
 
 
-def test_get_schema_version(fake_settings_dict):
+def test_get_schema_version(fake_settings_dict: SettingsDict):
     # Arrange & Act
     schema_version = migrations.get_schema_version(fake_settings_dict)
 
@@ -115,7 +116,7 @@ def test_get_current_schema_version(mocker: "pytest_mock.MockerFixture"):
     assert result == version
 
 
-def test_migrate_without_parameters(mocker):
+def test_migrate_without_parameters(mocker: "pytest_mock.MockerFixture"):
     # Arrange
     mock_auto_migrate = mocker.patch(
         "cobbler_tftp.settings.migrations.migrate", return_value=SettingsDict
@@ -157,7 +158,14 @@ def test_migrate_without_parameters(mocker):
         ),
     ],
 )
-def test_migrate(settings_dict, settings_path, old, new, expected, expected_exception):
+def test_migrate(
+    settings_dict: SettingsDict,
+    settings_path: pathlib.Path,
+    old: migrations.CobblerTftpSchemaVersion,
+    new: migrations.CobblerTftpSchemaVersion,
+    expected: Optional[SettingsDict],
+    expected_exception: Any,
+):
     # Arrange
     if expected is not None and old and new is None:
         expected = expected()
@@ -169,7 +177,9 @@ def test_migrate(settings_dict, settings_path, old, new, expected, expected_exce
 
 
 def test_auto_migrate_calls_migrate(
-    mocker: "pytest_mock.MockerFixture", fake_settings_dict, settings_path
+    mocker: "pytest_mock.MockerFixture",
+    fake_settings_dict: SettingsDict,
+    settings_path: pathlib.Path,
 ):
     # Arrange
     migrations.VERSION_LIST[
@@ -187,7 +197,9 @@ def test_auto_migrate_calls_migrate(
     mock_migrate.assert_called_once_with(fake_settings_dict, settings_path)
 
 
-def test_auto_migrate_raises_runtime_error(fake_settings_dict, settings_path):
+def test_auto_migrate_raises_runtime_error(
+    fake_settings_dict: SettingsDict, settings_path: pathlib.Path
+):
     # Arrange
     fake_settings_dict["auto_migrate_settings"] = False
 
@@ -196,7 +208,9 @@ def test_auto_migrate_raises_runtime_error(fake_settings_dict, settings_path):
         migrations.auto_migrate(fake_settings_dict, settings_path)
 
 
-def test_auto_migrate_raises_value_error(fake_settings_dict, settings_path):
+def test_auto_migrate_raises_value_error(
+    fake_settings_dict: SettingsDict, settings_path: pathlib.Path
+):
     # Arrange
     fake_settings_dict["schema"] = "not float"
 
@@ -206,17 +220,19 @@ def test_auto_migrate_raises_value_error(fake_settings_dict, settings_path):
 
 
 def test_auto_migrate_raises_value_error_if_verions_empty(
-    fake_settings_dict, settings_path
+    fake_settings_dict: SettingsDict, settings_path: pathlib.Path
 ):
     # Arrange
-    fake_settings_dict["schema"] = migrations.EMPTY_VERSION
+    fake_settings_dict["schema"] = migrations.EMPTY_VERSION  # type: ignore[reportArgumentType]
 
     # Act and Assert
     with pytest.raises(ValueError):
         migrations.auto_migrate(fake_settings_dict, settings_path)
 
 
-def test_validate(mocker, fake_settings_dict):
+def test_validate(
+    mocker: "pytest_mock.MockerFixture", fake_settings_dict: SettingsDict
+):
     # Arrange
     mock_validation_module = mocker.MagicMock()
     mock_validation_module.validate = mocker.MagicMock(return_value=True)
@@ -235,7 +251,9 @@ def test_validate(mocker, fake_settings_dict):
     assert result is True
 
 
-def test_normalize(mocker, fake_settings_dict):
+def test_normalize(
+    mocker: "pytest_mock.MockerFixture", fake_settings_dict: SettingsDict
+):
     # Arrange
     mock_validation_module = mocker.MagicMock()
     mock_validation_module.normalize = mocker.MagicMock(return_value=True)

--- a/tests/unittests/application_settings/test_settings.py
+++ b/tests/unittests/application_settings/test_settings.py
@@ -4,11 +4,15 @@ Tests for the application settings module.
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 
 from cobbler_tftp.settings import Settings, SettingsFactory
+
+if TYPE_CHECKING:
+    import pytest_mock
 
 
 @pytest.fixture
@@ -19,7 +23,7 @@ def settings_factory():
     return SettingsFactory()
 
 
-def assert_default_settings(settings):
+def assert_default_settings(settings: Settings):
     assert settings.auto_migrate_settings is False
     assert settings.is_daemon is True
     assert str(settings.pid_file_path) == "/run/cobbler-tftp.pid"
@@ -33,7 +37,7 @@ def assert_default_settings(settings):
     assert str(settings.logging_conf) == "/etc/cobbler-tftp/logging.conf"
 
 
-def assert_customized_settings(settings):
+def assert_customized_settings(settings: Settings):
     assert settings.auto_migrate_settings is True
     assert settings.is_daemon is False
     assert settings.uri == "http://testmachine.testnetwork.com/api"
@@ -46,7 +50,7 @@ def assert_customized_settings(settings):
 
 
 def test_build_settings_with_default_config_file(
-    settings_factory: SettingsFactory, mocker
+    settings_factory: SettingsFactory, mocker: "pytest_mock.MockerFixture"
 ):
     """
     Test the ``build_settings`` function without passing a config file path or additional arguments.
@@ -63,7 +67,7 @@ def test_build_settings_with_default_config_file(
 
 
 def test_build_settings_with_valid_config_file(
-    settings_factory: SettingsFactory, mocker
+    settings_factory: SettingsFactory, mocker: "pytest_mock.MockerFixture"
 ):
     valid_file_path = Path("tests/test_data/valid_config.yml")
     settings = settings_factory.build_settings(valid_file_path)
@@ -73,7 +77,7 @@ def test_build_settings_with_valid_config_file(
 
 
 def test_build_settings_with_absolute_config_path(
-    settings_factory: SettingsFactory, mocker
+    settings_factory: SettingsFactory, mocker: "pytest_mock.MockerFixture"
 ):
     absolute_path = Path("tests/test_data/valid_config.yml").absolute()
     settings = settings_factory.build_settings(absolute_path)
@@ -83,7 +87,7 @@ def test_build_settings_with_absolute_config_path(
 
 
 def test_build_settings_with_invalid_config_file(
-    settings_factory: SettingsFactory, mocker
+    settings_factory: SettingsFactory, mocker: "pytest_mock.MockerFixture"
 ):
     # Pass path to invalid yaml file in /test_data/invalid_config.yml
     # Assert that YAMLError gets raised
@@ -99,7 +103,7 @@ def test_build_settings_with_invalid_config_file(
 
 
 def test_build_settings_with_missing_config_file(
-    settings_factory: SettingsFactory, capsys
+    settings_factory: SettingsFactory, capsys: pytest.CaptureFixture[str]
 ):
     """
     Test the ``build_settings`` function while passing it a path without a config file present.


### PR DESCRIPTION
## Linked Items

Fixes #4

## Description

> This PR has a couple of open points that are not yet done. This message will vanish when the PR can be reviewed.

This PR fixes the bug that the automatically generated code documentation doesn't show.

Mainly however the PR adds Dockerfiles for three different environments:

- Development: Used for local development, execution of the dockerfile retrieves the project's dependencies from pip.
- Production: Uses the current stable release project for Cobbler, dependencies get pulled in from the OBS at image build time.
- Rolling: Uses the unstable rolling release project for Cobbler containers, dependencies get pulled in from the OBS at image build time.

The submission of the dockerfiles is not yet automatically done.

## Behaviour changes

Old: Cobbler-TFTP could only be run bare-metal or in a VM

New: Containerized deployments are now also possible.

## Category

This is related to a:

- [x] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
