### PR TITLE
Feature: Add version file support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ cobbler-tftp = "cobbler_tftp.cli:cli"
 profile = "black"
 
 [tool.setuptools_scm]
+version_file = "src/cobbler_tftp/data/version.cfg"
+version_file_template = """
+[cobbler-tftp]
+gitdate = {scm_version.time}
+gitstamp = {scm_version.node}
+version = {version}
+version_tuple = [{version_tuple[0]}, {version_tuple[1]}, {version_tuple[2]}]
+"""
 
 [tool.towncrier]
 directory = "changelog.d"

--- a/src/cobbler_tftp/cli.py
+++ b/src/cobbler_tftp/cli.py
@@ -203,6 +203,7 @@ def setup(
     try:
         config_path.mkdir(parents=True, exist_ok=True)
         source_path = files("cobbler_tftp.settings.data")  # type: ignore
+        source_path_version = files("cobbler_tftp.data")
         if systemd:
             systemd_path.mkdir(parents=True, exist_ok=True)
             copy_file(source_path, systemd_path, "cobbler-tftp.service")
@@ -213,6 +214,7 @@ def setup(
             [("/etc/cobbler-tftp", config_dir)],
         )
         copy_file(source_path, config_path, "logging.conf")
+        copy_file(source_path_version, config_path, "version.cfg")
     except PermissionError as err:
         click.echo(err, err=True)
         click.echo(

--- a/src/cobbler_tftp/data/version.cfg
+++ b/src/cobbler_tftp/data/version.cfg
@@ -1,0 +1,6 @@
+[cobbler-tftp]
+gitdate = Mon Jan 01 00:00:00 2000 +0000
+gitstamp = aaaaaaaaa
+builddate = Mon Jan 01 00:00:00 2000
+version = 0.0.0
+version_tuple = [0, 0, 0]

--- a/src/cobbler_tftp/data/version.cfg
+++ b/src/cobbler_tftp/data/version.cfg
@@ -1,6 +1,5 @@
 [cobbler-tftp]
 gitdate = Mon Jan 01 00:00:00 2000 +0000
 gitstamp = aaaaaaaaa
-builddate = Mon Jan 01 00:00:00 2000
 version = 0.0.0
 version_tuple = [0, 0, 0]


### PR DESCRIPTION
## Linked Items

Fixes #13

## Description

This PR adds support for an on-disk version file in a similar format to Cobbler. The version information is not printed when calling `cobbler-tftp version` with this implementation. If users insist or we realize that this is useful, then we can change the implementation in my eyes. The "complicated" part of having the information available is done in my eyes with this PR.

## Behaviour changes

Old: The application didn't have a version file.

New: A version file is present on disk.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
