### PR TITLE
Fix miscellaneous issues 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
+DOCKER_IMAGE_NAME=cobbler-tftp-pkg
+DOCKER_IMAGE_TAG_DEBIAN=debian-13
+DOCKER_IMAGE_TAG_OPENSUSE_TW=opensuse-tumbleweed
+
 build:
 	@python3 -m setuptools_scm --force-write-version-files
 	@python3 -m pip wheel --verbose --use-pep517 --wheel-dir ./build .
 
+
+
 deb:
-	@docker build -t localhost/cobbler-tftp-pkg:debian-13 -f docker/deb/Debian_13/Dockerfile .
-	@docker run --rm -v $(CURDIR)/debs/Debian_13:/usr/src/cobbler-tftp/deb-build -v $(CURDIR):/workspace localhost/cobbler-tftp-pkg:debian-13
+	@docker build -t localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} -f docker/deb/Debian_13/Dockerfile .
+	@docker run --rm -v $(CURDIR)/debs/Debian_13:/usr/src/cobbler-tftp/deb-build -v $(CURDIR):/workspace localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN}
+	@docker run --rm -v $(CURDIR):/workspace --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} bash -c 'dpkg -i /workspace/debs/Debian_13/cobbler-tftp*.deb'
 
 rpm:
-	@docker build -t localhost/cobbler-tftp-pkg:opensuse-tumblewed -f docker/rpm/openSUSE_tumbleweed/Dockerfile .
-	@docker run --rm -v $(CURDIR)/rpms/openSUSE_tumbleweed:/root/rpmbuild/RPMS -v $(CURDIR):/workspace localhost/cobbler-tftp-pkg:opensuse-tumblewed
+	@docker build -t localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW} -f docker/rpm/openSUSE_tumbleweed/Dockerfile .
+	@docker run --rm -v $(CURDIR)/rpms/openSUSE_tumbleweed:/root/rpmbuild/RPMS -v $(CURDIR):/workspace localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW}
+	@docker run --rm -v $(CURDIR):/workspace --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW} rpm -i /workspace/rpms/openSUSE_tumbleweed/noarch/*.rpm
 
 clean:
 	@rm -rf debs rpms build .pybuild

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_IMAGE_NAME=cobbler-tftp-pkg
+DOCKER_IMAGE_TAG_OCI=oci
 DOCKER_IMAGE_TAG_DEBIAN=debian-13
 DOCKER_IMAGE_TAG_OPENSUSE_TW=opensuse-tumbleweed
 
@@ -6,7 +7,8 @@ build:
 	@python3 -m setuptools_scm --force-write-version-files
 	@python3 -m pip wheel --verbose --use-pep517 --wheel-dir ./build .
 
-
+container-image:
+	@docker build -t localhost/${DOCKER_IMAGE_TAG_OCI} -f docker/production/Dockerfile .
 
 deb:
 	@docker build -t localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} -f docker/deb/Debian_13/Dockerfile .
@@ -24,4 +26,4 @@ clean:
 	@rm -rf src/*.egg-info src/*.dist-info
 	@rm -f src/cobbler_tftp/data/version.cfg
 
-.PHONY: rpm deb build clean
+.PHONY: rpm deb container-image build clean

--- a/changelog.d/35.fixed
+++ b/changelog.d/35.fixed
@@ -1,0 +1,1 @@
+Specfile requires wrong version of Python for Leap

--- a/cobbler-tftp.spec
+++ b/cobbler-tftp.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package cobbler-tftp
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,8 +17,7 @@
 
 %define python_package_name cobbler_tftp
 
-%define pythons python3
-%{?sle15_python_module_pythons}
+%{?single_pythons_311plus}
 Name:           cobbler-tftp
 Version:        %{version}
 Release:        0
@@ -45,19 +44,20 @@ BuildRequires:  %{python_module PyYAML}
 BuildRequires:  %{python_module click}
 BuildRequires:  %{python_module schema}
 
-Requires:       python3-fbtftp
-Requires:       python3-python-daemon
-Requires:       python3-PyYAML
-Requires:       python3-click
-Requires:       python3-schema
+Requires:       python-fbtftp
+Requires:       python-python-daemon
+Requires:       python-PyYAML
+Requires:       python-click
+Requires:       python-schema
 BuildArch:      noarch
+%python_subpackages
 
 %description
 Cobbler-TFTP is a lightweight CLI application written in Python that serves as a stateless TFTP server.
 It seamlessly integrates with Cobbler to generate and serve boot configuration files dynamically to managed machines.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 cp -r %{_sourcedir}/cobbler-tftp-%{version}/.git %{_builddir}/cobbler-tftp-%{version}
@@ -81,7 +81,7 @@ cp -r %{_sourcedir}/cobbler-tftp-%{version}/.git %{_builddir}/cobbler-tftp-%{ver
 %postun
 %service_del_postun cobbler-tftp.service
 
-%files
+%files %{python_files}
 %license LICENSE
 %doc README.md
 %{_bindir}/cobbler-tftp

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,9 +8,10 @@ However, these methods of Installation will be available:
 Installation Requirements
 =========================
 
-To install and use Cobbler-TFTP, please make sure you have *at least Python 3.6* installed.
+To install and use Cobbler-TFTP, please make sure you have *at least Python 3.8* installed.
 
-### Install via `pip`
+Install via `pip`
+=================
 
 Cobbler-TFTP is published to PyPi.
 To install it, please make sure that your system fulfills the installation requirements listed above and has `pip`,


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

## Description

This PR is trying to fix a few smaller issues that I noticed:

- The `Requires` of the RPM are Python 3 and not 3.11 for openSUSE Leap.
- The documentation has a formatting issue and a small content issue in the Installation guide.
- The documentation has an empty getting-started guide.
- The `make rpm` and `make deb` targets were missing install checks.
- The Makefile was missing a target for the production OCI container.
- The copyright in the Specfile was outdated.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
