### PR TITLE
Setup: Add explicit depends on vcs-versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Deps for installing project
         run: pip install wheel setuptools
       - name: Install Deps with pip
-        run: pip install .
+        run: pip install .[optional_setup]
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,9 @@ doc =
 dev_requires =
   pip>=21.3.1
 
+optional_setup =
+  vcs-versioning>=1.0.0.dev0
+
 [options.packages.find]
 where=src
 exclude =


### PR DESCRIPTION
## Linked Items

Fixes the build issue on main.

## Description

<!-- What does this PR do? -->

## Behaviour changes

Old: Build fails with newer versions of setuptools_scm

New: Build works on all versions of setuptools_scm

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
