### PR TITLE
Python 3.14+ compability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
           python3-wheel
           python3-libvirt-python
           python3-netifaces
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Mark directory as safe for Git
         run: git config --global --add safe.directory /__w/cobbler-tftp/cobbler-tftp
       - name: Install towncrier
@@ -26,7 +26,7 @@ jobs:
         run: towncrier --yes
       - name: Create Pull Request
         # https://github.com/peter-evans/create-pull-request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "[Bot] Add changelog for new version"
           delete-branch: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -67,6 +67,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -19,10 +19,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Log in to the Container registry
         # https://github.com/docker/login-action
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -30,12 +30,12 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         # https://github.com/docker/metadata-action
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/production/Dockerfile

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           make deb
 
       - name: Upload DEB Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cobbler-tftp-deb-${{ env.REPO_TAG }}
           path: ./debs/**/*.deb
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
           make rpm
 
       - name: Upload RPM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cobbler-tftp-rpm-${{ env.REPO_TAG }}
           path: ./rpms/**/*.rpm
@@ -72,12 +72,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 
@@ -114,7 +114,7 @@ jobs:
           ls dist/
 
       - name: Upload WHL Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cobbler-tftp-wheel-${{ env.REPO_TAG }}
           path: dist/*.whl
@@ -127,7 +127,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -143,11 +143,11 @@ jobs:
       # https://github.com/actions/download-artifact
       - name: Download all artifacts
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           # Put release artifacts here.
           artifacts: "cobbler-tftp-wheel-${{ env.REPO_TAG }}, cobbler-tftp-rpm-${{ env.REPO_TAG }}, cobbler-tftp-deb-${{ env.REPO_TAG }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install importlib-resources
           pip install .[lint_requires,tests_require]
       - name: Analysing the code with pyright
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
     name: rstcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.13
     - name: Install dependencies
@@ -25,9 +25,9 @@ jobs:
       name: black formatter
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Check files using the black formatter
-          uses: psf/black@stable
+          uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # stable
           with:
             options: "--check --safe --verbose"
             version: "22.3.0"
@@ -38,9 +38,9 @@ jobs:
         matrix:
           python-version: ["3.11", "3.12", "3.13"]
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -54,12 +54,12 @@ jobs:
     name: isort
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.13
-    - uses: isort/isort-action@master
+    - uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1.1.1
       with:
         requirementsFiles: "pyproject.toml"
 

--- a/.github/workflows/newsfragment_checker.yml
+++ b/.github/workflows/newsfragment_checker.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.13
           cache: pip
           cache-dependency-path: setup.py
       - run: pip install -e .[doc]

--- a/.github/workflows/newsfragment_checker.yml
+++ b/.github/workflows/newsfragment_checker.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.13
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.12
       - name: Update package cache
@@ -48,9 +48,9 @@ jobs:
         run: echo "Match is $MATCH"
       - name: Publish distribution to Test PyPI
         if: startsWith(github.ref, 'refs/tags/v') && (steps.check-tag.outputs.match == 'prerelease' || steps.check-tag.outputs.match == 'release')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-tag.outputs.match == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,3 +36,24 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage.xml
+
+  test-latest-python:
+    name: Test against latest Python (incl. pre-releases)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up latest Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        allow-prereleases: true
+
+    - name: Install dependencies
+      run: pip install .[tests_require]
+
+    - name: Run tests
+      run: pytest -v tests/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.x
 
@@ -31,7 +31,7 @@ jobs:
 
     # https://github.com/codacy/codacy-coverage-reporter-action
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
       continue-on-error: true
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -44,10 +44,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up latest Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.x'
         allow-prereleases: true

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ container-image-dev:
 
 deb:
 	@docker build -t localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} -f docker/deb/Debian_13/Dockerfile .
-	@docker run --rm -v $(CURDIR)/debs/Debian_13:/usr/src/cobbler-tftp/deb-build -v $(CURDIR):/workspace localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN}
-	@docker run --rm -v $(CURDIR):/workspace --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} bash -c 'dpkg -i /workspace/debs/Debian_13/cobbler-tftp*.deb'
+	@docker run --rm -v $(CURDIR)/debs/Debian_13:/usr/src/cobbler-tftp/deb-build:Z -v $(CURDIR):/workspace:Z localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN}
+	@docker run --rm -v $(CURDIR):/workspace:Z --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_DEBIAN} bash -c 'dpkg -i /workspace/debs/Debian_13/cobbler-tftp*.deb'
 
 rpm:
 	@docker build -t localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW} -f docker/rpm/openSUSE_tumbleweed/Dockerfile .
-	@docker run --rm -v $(CURDIR)/rpms/openSUSE_tumbleweed:/root/rpmbuild/RPMS -v $(CURDIR):/workspace localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW}
-	@docker run --rm -v $(CURDIR):/workspace --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW} rpm -i /workspace/rpms/openSUSE_tumbleweed/noarch/*.rpm
+	@docker run --rm -v $(CURDIR)/rpms/openSUSE_tumbleweed:/root/rpmbuild/RPMS:Z -v $(CURDIR):/workspace:Z localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW}
+	@docker run --rm -v $(CURDIR):/workspace:Z --entrypoint '' localhost/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_OPENSUSE_TW} rpm -i /workspace/rpms/openSUSE_tumbleweed/noarch/*.rpm
 
 clean:
 	@rm -rf debs rpms build .pybuild

--- a/changelog.d/39.fixed
+++ b/changelog.d/39.fixed
@@ -1,0 +1,1 @@
+Replace the deprecated `importlib.abc.Traversable` alias, which is removed in Python 3.14, with `importlib.resources.abc.Traversable`

--- a/cobbler-tftp.dsc
+++ b/cobbler-tftp.dsc
@@ -1,0 +1,21 @@
+Format: 1.0
+Source: cobbler-tftp
+Maintainer: The Cobbler Authors <cobbler.project@gmail.com>
+Standards-Version: 4.5.1
+Version: 0.0.1
+Homepage: https://cobbler.github.io
+Build-Depends:
+ debhelper (>= 12),
+ dh-python,
+ git-core,
+ python3 (>= 3.11),
+ python3-click,
+ python3-daemon,
+ python3-fbtftp,
+ python3-pytest,
+ python3-pytest-mock,
+ python3-schema,
+ python3-setuptools,
+ python3-setuptools-scm,
+ python3-yaml
+DEBTRANSFORM-TAR: cobbler-tftp-0.0.1.tar.gz

--- a/cobbler-tftp.spec
+++ b/cobbler-tftp.spec
@@ -17,9 +17,20 @@
 
 %define python_package_name cobbler_tftp
 
+%if 0%{?fedora} || 0%{?rhel}
+%define python_daemon_name python3-daemon
+%else
+%define python_daemon_name python3-python-daemon
+%endif
+
+%if 0%{?suse_version}
 %{?single_pythons_311plus}
+%endif
+
+%global __python %{__python3}
+
 Name:           cobbler-tftp
-Version:        %{version}
+Version:        0
 Release:        0
 Summary:        The TFTP server daemon for Cobbler
 License:        GPL-2.0-or-later
@@ -30,26 +41,37 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
 BuildRequires:  systemd-rpm-macros
 %endif
+%if 0%{?fedora} || 0%{?rhel}
+# Provides %%pyproject_wheel / %%pyproject_install, the Fedora/RHEL equivalent
+# of SUSE's python-rpm-macros pyproject buildsystem macros
+BuildRequires:  pyproject-rpm-macros
+%endif
 
 BuildRequires:  fdupes
 BuildRequires:  git
-BuildRequires:  %{python_module base >= 3.8}
-BuildRequires:  %{python_module pip}
-BuildRequires:  %{python_module setuptools}
-BuildRequires:  %{python_module setuptools_scm >= 8.0.0}
-BuildRequires:  %{python_module wheel}
-BuildRequires:  %{python_module fbtftp}
-BuildRequires:  %{python_module python-daemon}
-BuildRequires:  %{python_module PyYAML}
-BuildRequires:  %{python_module click}
-BuildRequires:  %{python_module schema}
+BuildRequires:  python3-devel >= 3.11
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm >= 8.0.0
+BuildRequires:  python3-wheel
+BuildRequires:  python3-fbtftp
+BuildRequires:  %{python_daemon_name}
+BuildRequires:  python3-PyYAML
+BuildRequires:  python3-click
+BuildRequires:  python3-schema
 
 Requires:       python3-fbtftp
-Requires:       python3-python-daemon
+Requires:       %{python_daemon_name}
 Requires:       python3-PyYAML
 Requires:       python3-click
 Requires:       python3-schema
 BuildArch:      noarch
+
+%if 0%{?fedora} || 0%{?rhel}
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#Automatically-generated-dependencies
+# Disable it because it trips over python3-cheetah
+%{?python_disable_dependency_generator}
+%endif
 
 %description
 Cobbler-TFTP is a lightweight CLI application written in Python that serves as a stateless TFTP server.
@@ -60,13 +82,21 @@ It seamlessly integrates with Cobbler to generate and serve boot configuration f
 
 %build
 cp -r %{_sourcedir}/cobbler-tftp-%{version}/.git %{_builddir}/cobbler-tftp-%{version}
+%if 0%{?fedora} || 0%{?rhel}
+%{python3} -m setuptools_scm --force-write-version-files
+%else
 %python_exec -m setuptools_scm --force-write-version-files
+%endif
 %pyproject_wheel
 
 %install
 %pyproject_install
+%if 0%{?fedora} || 0%{?rhel}
+PYTHONPATH=%{buildroot}%{python3_sitelib} %{buildroot}%{_bindir}/cobbler-tftp setup --systemd-dir=%{_unitdir} --install-prefix=%{buildroot}
+%else
 %python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} %{buildroot}%{_bindir}/cobbler-tftp setup --systemd-dir=%{_unitdir} --install-prefix=%{buildroot}
 %fdupes %{buildroot}%{_prefix}
+%endif
 
 %pre
 %service_add_pre cobbler-tftp.service

--- a/debian/rules
+++ b/debian/rules
@@ -21,11 +21,6 @@ override_dh_auto_clean:
 override_dh_install:
 	dh_install --sourcedir="debian/python3-cobbler-tftp"
 
-# Skip test execution
-# =========================== short test summary info ============================
-# ERROR tests/unittests/application_settings/test_migrations.py::test_auto_migrate_calls_migrate - ModuleNotFoundError: No module named 'src'
-# ERROR tests/unittests/application_settings/test_migrations.py::test_auto_migrate_raises_runtime_error - ModuleNotFoundError: No module named 'src'
-# ERROR tests/unittests/application_settings/test_migrations.py::test_auto_migrate_raises_value_error - ModuleNotFoundError: No module named 'src'
-# ERROR tests/unittests/application_settings/test_migrations.py::test_auto_migrate_raises_value_error_if_verions_empty - ModuleNotFoundError: No module named 'src'
-# ================== 26 passed, 21 warnings, 4 errors in 0.20s ===================
-dh_auto_test:
+# Skip test execution: running under pybuild currently fails with
+# "ModuleNotFoundError: No module named 'src'" for the migrations tests.
+override_dh_auto_test:

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -17,7 +17,7 @@ ENV container=docker
 ENV COBBLER_TFTP__TFTP__PORT=6969
 
 # Custom repository
-RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/openSUSE_Tumbleweed/ "Cobbler 3.4.x release project" \
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release40/openSUSE_Tumbleweed/ "Cobbler 4.0.x release project" \
     && zypper --gpg-auto-import-keys refresh
 
 # Dependencies

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -13,7 +13,7 @@ FROM registry.suse.com/bci/bci-base:16.0
 LABEL org.opencontainers.image.title="cobbler-tftp"
 LABEL org.opencontainers.image.description="This image runs the (nearly) stateless Cobbler TFTP server."
 LABEL org.opencontainers.image.version="release34.%RELEASE%"
-LABEL org.opensuse.reference="registry.opensuse.org/systemsmanagement/cobbler/release34/cobbler-tftp:release34.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/systemsmanagement/cobbler/release40/cobbler-tftp:release34.%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
@@ -24,7 +24,7 @@ ENV COBBLER_TFTP__TFTP__PORT=6969
 
 # Custom repository
 RUN zypper ar https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard/openSUSE:Leap:16.0.repo \
-    && zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/16.0/ "Cobbler 3.4.x release project" \
+    && zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release40/16.0/ "Cobbler 4.0.x release project" \
     && zypper --gpg-auto-import-keys refresh
 
 # Cobbler-TFTP and tftp client

--- a/docker/rolling/Dockerfile
+++ b/docker/rolling/Dockerfile
@@ -23,7 +23,7 @@ ENV container=docker
 ENV COBBLER_TFTP__TFTP__PORT=6969
 
 # Custom repository
-RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/openSUSE_Tumbleweed/ "Cobbler 3.4.x release project" \
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release40/openSUSE_Tumbleweed/ "Cobbler 4.0.x release project" \
     && zypper --gpg-auto-import-keys refresh
 
 # Dependencies

--- a/docker/rpm/entrypoint.sh
+++ b/docker/rpm/entrypoint.sh
@@ -14,6 +14,11 @@ echo " ===> Copy required files into build environment"
 rm -rf ~/rpmbuild/SOURCES/*
 cp "/cobbler-tftp-${VERSION}.tar.gz" ~/rpmbuild/SOURCES/
 cp cobbler-tftp.spec ~/rpmbuild/SPECS/
+# The spec's "Version: 0" is a placeholder OBS's set_version source service
+# rewrites at submission time; do the same rewrite here so Source0's
+# %{name}-%{version}.tar.gz matches the tarball actually built above
+# (rpmbuild's Version: tag would otherwise override --define version=...).
+sed -i "s/^Version:.*/Version:        ${VERSION}/" ~/rpmbuild/SPECS/cobbler-tftp.spec
 cd ~/rpmbuild/SOURCES || exit
 tar -xzvf "./cobbler-tftp-${VERSION}.tar.gz"
 cd "/workspace" || exit

--- a/docker/rpm/openSUSE_tumbleweed/Dockerfile
+++ b/docker/rpm/openSUSE_tumbleweed/Dockerfile
@@ -7,24 +7,25 @@ WORKDIR /workspace
 VOLUME /workspace
 
 # Install required dependencies
-RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release34/openSUSE_Tumbleweed/systemsmanagement:cobbler:release34.repo && \
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release40/openSUSE_Tumbleweed/systemsmanagement:cobbler:release40.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n install \
     rpm-build \
     python-rpm-macros \
-    python313 \
-    python313-pip \
-    python313-setuptools \
-    python313-setuptools_scm \
-    python313-wheel \
-    python313-build \
-    python313-click \
-    python313-python-daemon \
-    python313-PyYAML \
-    python313-importlib-metadata \
-    python313-importlib-resources \
-    python313-schema \
-    python313-fbtftp \
+    python3 \
+    python3-devel \
+    python3-pip \
+    python3-setuptools \
+    python3-setuptools_scm \
+    python3-wheel \
+    python3-build \
+    python3-click \
+    python3-python-daemon \
+    python3-PyYAML \
+    python3-importlib-metadata \
+    python3-importlib-resources \
+    python3-schema \
+    python3-fbtftp \
     git \
     fdupes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dynamic = [
   "version",
   "dependencies",
   "readme",
-  "optional-dependencies"
+  "optional-dependencies",
+  "requires-python"
 ]
 
 [project.scripts]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,15 @@ license = GPL v2.0 License
 classifiers =
   Natural Language :: English
   Operating System :: OS Independent
-  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
 
 [options]
+python_requires = >=3.11
 zip_safe = True
 package_dir=
   =src

--- a/src/cobbler_tftp/settings/migrations/__init__.py
+++ b/src/cobbler_tftp/settings/migrations/__init__.py
@@ -111,8 +111,10 @@ EMPTY_VERSION: CobblerTftpSchemaVersion = CobblerTftpSchemaVersion()
 VERSION_LIST: Dict[CobblerTftpSchemaVersion, ModuleType] = {}
 _CONFIG_FILE_PATH: Path = Path()
 
-with importlib_resources.path(__package__, "versioning.cfg") as config_path:  # type: ignore
-    _CONFIG_FILE_PATH = config_path  # type: ignore
+with importlib_resources.as_file(
+    importlib_resources.files(__name__).joinpath("versioning.cfg")
+) as config_path:
+    _CONFIG_FILE_PATH = config_path
 
 
 def __validate_module(name: ModuleType) -> bool:
@@ -201,13 +203,17 @@ def discover_migrations() -> None:
         * the module must contain the following methods: ``validate()``, ``normalize()``, ``migrate()``
         * those version must have a certain signature
     """
-    # importlib.resources.contents is deprecated with 3.11 but files().iterdir() is not yet available in 3.7
-    folder_iterator = importlib_resources.contents("cobbler_tftp.settings.migrations")  # type: ignore
+    folder_iterator = (
+        entry.name
+        for entry in importlib_resources.files(
+            "cobbler_tftp.settings.migrations"
+        ).iterdir()
+    )
     filename_regex = r"v[0-9]*_[0-9]*.py"
-    for files in folder_iterator:  # type: ignore
-        if not re.match(filename_regex, files):  # type: ignore
+    for files in folder_iterator:
+        if not re.match(filename_regex, files):
             continue
-        files = Path(files)  # type: ignore
+        files = Path(files)
         if files.is_symlink():
             continue
         migration_name = ""

--- a/src/cobbler_tftp/utils.py
+++ b/src/cobbler_tftp/utils.py
@@ -2,13 +2,13 @@
 Various utility functions for cobbler-tftp
 """
 
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 
 def copy_file(
-    src_dir: Traversable,  # type: ignore
+    src_dir: Traversable,
     dst_dir: Path,
     name: str,
     patch: Optional[List[Tuple[str, str]]] = None,
@@ -22,10 +22,10 @@ def copy_file(
     :param name: Name of the file (in both directories).
     :param patch: List of (old, new) strings to replace in the file.
     """
-    src = src_dir / name  # type: ignore
+    src = src_dir / name
     dst = dst_dir / name
-    contents: bytes = src.read_bytes()  # type: ignore
+    contents: bytes = src.read_bytes()
     if patch is not None:
         for old, new in patch:
-            contents = contents.replace(old.encode("UTF-8"), new.encode("UTF-8"))  # type: ignore
-    dst.write_bytes(contents)  # type: ignore
+            contents = contents.replace(old.encode("UTF-8"), new.encode("UTF-8"))
+    dst.write_bytes(contents)

--- a/tests/unittests/application_settings/conftest.py
+++ b/tests/unittests/application_settings/conftest.py
@@ -36,8 +36,9 @@ def fake_settings_dict() -> SettingsDict:
 
 @pytest.fixture
 def settings_path() -> Path:
-    # pyright cannot work with our try-except import for older Python versions
-    with importlib_resources.path(  # type: ignore[reportUnkownMemberType]
-        "src.cobbler_tftp.settings.data", "settings.yml"
-    ) as settings_path:  # type: ignore[reportUnkownVariableType]
-        return settings_path  # type: ignore[reportUnkownVariableType]
+    with importlib_resources.as_file(
+        importlib_resources.files("src.cobbler_tftp.settings.data").joinpath(
+            "settings.yml"
+        )
+    ) as settings_path:
+        return settings_path

--- a/tests/unittests/application_settings/test_migrations.py
+++ b/tests/unittests/application_settings/test_migrations.py
@@ -56,11 +56,15 @@ def test_discover_migrations(mocker: "pytest_mock.MockerFixture"):
         "not_a_migration.py",
         "v4_0.py",
     ]
-    # Replace importlib_resources.contents with a mock object that returns the mock contents
-    mock_importlib = mocker.patch(
-        "cobbler_tftp.settings.migrations.importlib_resources.contents",
-        return_value=mock_migrations,
+    # Replace importlib_resources.files(...).iterdir() with a mock that yields
+    # fake directory entries exposing a `.name` attribute
+    mock_entries = [mocker.MagicMock() for _ in mock_migrations]
+    for entry, name in zip(mock_entries, mock_migrations):
+        entry.name = name
+    mock_files = mocker.patch(
+        "cobbler_tftp.settings.migrations.importlib_resources.files",
     )
+    mock_files.return_value.iterdir.return_value = mock_entries
     # Replace __load_migration_modules with a mock object that does nothing
     mock_load_migration = mocker.patch(
         "cobbler_tftp.settings.migrations.__load_migration_modules",
@@ -81,7 +85,7 @@ def test_discover_migrations(mocker: "pytest_mock.MockerFixture"):
         ]
     )
 
-    mock_importlib.assert_called_once_with("cobbler_tftp.settings.migrations")
+    mock_files.assert_called_once_with("cobbler_tftp.settings.migrations")
 
 
 def test_get_schema(mocker: "pytest_mock.MockerFixture"):


### PR DESCRIPTION
## Linked Items

Fixes #39

## Description

This PR increases the minimum required Python version to 3.11; through this, compatibility with 3.14+ is ensured. Lastly, this PR contains fixes for the packaging inside the OBS.

## Behaviour changes

None.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
